### PR TITLE
Add HF API endpoint support

### DIFF
--- a/README_HF_MODEL.md
+++ b/README_HF_MODEL.md
@@ -96,6 +96,7 @@ python test_hf_emotion_model.py
 ```bash
 # .env 파일에 설정
 KOELECTRA_MODEL_PATH=outputs/koelectra_emotion  # 로컬 모델 경로 (폴백용)
+HF_EMOTION_API_URL=https://hglww4g5jugd2khs.us-east-1.aws.endpoints.huggingface.cloud  # KoELECTRA Inference API
 ```
 
 ## API 참조

--- a/src/README.md
+++ b/src/README.md
@@ -90,6 +90,7 @@ MONGODB_DATABASE=novel_db
 
 # KoELECTRA Model
 KOELECTRA_MODEL_PATH=outputs/koelectra_emotion
+HF_EMOTION_API_URL=https://hglww4g5jugd2khs.us-east-1.aws.endpoints.huggingface.cloud
 ```
 
 ### 5. MongoDB 설정

--- a/src/utils/emotion_analyzer.py
+++ b/src/utils/emotion_analyzer.py
@@ -25,13 +25,14 @@ class EmotionAnalyzer:
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         
         if use_hf_api:
-            # API URL 지정 또는 모델명으로 생성
+            # API URL 지정 또는 환경 변수 사용
             if hf_api_url:
                 self.hf_api_url = hf_api_url
             else:
-                # model_name이 없으면 기본값 사용
-                model_id = model_name or "Jinuuuu/KoELECTRA_fine_tunning_emotion"
-                self.hf_api_url = f"https://api-inference.huggingface.co/models/{model_id}"
+                self.hf_api_url = os.getenv(
+                    "HF_EMOTION_API_URL",
+                    "https://hglww4g5jugd2khs.us-east-1.aws.endpoints.huggingface.cloud",
+                )
             print(f"Hugging Face Inference API 사용: {self.hf_api_url}")
         else:
             if use_local:


### PR DESCRIPTION
## Summary
- update `EmotionAnalyzer` to call a configurable HF inference endpoint
- document `HF_EMOTION_API_URL` env var for emotion API endpoint

## Testing
- `python -m py_compile src/utils/emotion_analyzer.py`

------
https://chatgpt.com/codex/tasks/task_e_685644cf3898832eb9554c4230851a3c